### PR TITLE
Update built-ins for Open VSX publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
         "archiver": "^3.0.3",
         "lerna": "2.4.0",
         "vsce": "1.70.0",
-        "fs-extra": "8.1.0"
+        "fs-extra": "8.1.0",
+        "capitalize": "^2.0.2"
     },
     "workspaces": [
         "vscode-builtin-extensions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,6 +3235,11 @@ caniuse-lite@^1.0.30001010:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001012.tgz#653ec635e815b9e0fb801890923b0c2079eb34ec"
   integrity sha512-7RR4Uh04t9K1uYRWzOJmzplgEOAXbfK72oVNokCdMzA67trrhPzy93ahKk1AWHiA0c58tD2P+NHqxrA8FZ+Trg==
 
+capitalize@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/capitalize/-/capitalize-2.0.2.tgz#d66855724fafc09f7f913131f89000a7879e6954"
+  integrity sha512-kX+ZpaqUSx1YcAKnZ6J4HZY0yaYc+RnIVkO+3ckeerj8lW0T+9GmyRekRF3PzH+46HHdsz2ma0S0NfTby/rojA==
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
The built-ins package.json are missing many fields that are
desirable to have so that the extension's page on Open VSX
will be populated correctly.

Fixes #19

How to test:

0) build this repo and obtain the `.vsix` from the `dist` folder
1) open [Open VSX](https://github.com/eclipse/openvsx) in Gitpod
2) create a `builtins` folder at the root
3) use a file manager for your OS and drag-and-drop the generated builtins to the GitPod file navigator, over the builtins folder
4) use the openvsx client to create the `vscode` namespace:
`$> cli/lib/ovsx create-namespace vscode -r http://localhost:8080 -p super_token`
4) use the openvsx client to publish a built-in extension to the (test) registry. e.g.:
`$> cli/lib/ovsx publish -r http://localhost:8080 -p super_token builtins/grunt-1.40.0-prel.vsix`
5) Open the web page for the registry (the one on port 3000) and search for the extension you published. Look at the first page and detailed page for the extension. 