### PR TITLE
include runtime dependencies for emmet

### DIFF
--- a/src/vscode-bundle.js
+++ b/src/vscode-bundle.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const rimraf = require('../vscode/node_modules/rimraf');
 const vfs = require('../vscode/node_modules/vinyl-fs');
 const ext = require('../vscode/build/lib/extensions');
-const { root, theiaExtension, extensions } = require('./paths.js')
+const { root, theiaExtension, extensions, run } = require('./paths.js')
 
 const backupNodeModules = () => {
     const move = (src, dest) => fs.existsSync(src) && fs.renameSync(src, dest);
@@ -23,4 +23,5 @@ rimraf.sync(extensions());
         stream.on('error', reject);
         stream.on('end', resolve);
     });
+    await run('yarn', ['install', '--production'], extensions('emmet'));
 })();


### PR DESCRIPTION
Fixes #18

As suggested here, I added one step to install the production dependencies for emmet: https://github.com/theia-ide/vscode-builtin-extensions/issues/18#issuecomment-600587985

It seems to fix #18 and as well make the emmet built-in work: see second video here: https://github.com/theia-ide/vscode-builtin-extensions/issues/18#issuecomment-600639298

How to test

Build this branch using yarn, then test the emmet built-in as per the following comment, and verify that this scenario no longer generates an exception: https://github.com/theia-ide/vscode-builtin-extensions/issues/18#issuecomment-600645599