### PR TITLE
[latest] publish built-ins to Open VSX registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,17 +97,22 @@ Publish packages with lerna to update versions properly across local packages, [
 
 ## Package built-ins as individual `.vsix`
 
-If required, step the version to be used for the extensions in `src/package-vsix.js`
+The version of the packaged built-ins is automatically taken from the VS Code's `package.json` and will also include the SHA of the HEAD VS Code commit if packaging a "next" version.
 
-    // bump to publish
-    let version = '0.2.1';
+To package, use one of the following:
 
-Generate .vsix extensions
+Latest / solid revision:
 
     yarn package-vsix:latest
 
-or
+Next / interim revision:
 
     yarn package-vsix:next
 
-The `.vsix` extensions will be under folder `./dist`
+The generated `.vsix` will be under folder `./dist`
+
+## Publishing VS Code "Builtins" to open-vsx
+
+After generating the `.vsix` (see above), you may examine/test the extensions under folder `dist`. Remove any that you do not wish to be published (e.g. those not working well). When ready proceed with publishing:
+
+    yarn publish:latest

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
     "private": true,
     "scripts": {
-        "prepare": "yarn build:extensions && yarn bundle:extensions && yarn build && yarn package-vsix:latest",
+        "prepare": "yarn build:extensions && yarn bundle:extensions && yarn build && yarn package-vsix:next",
         "build": "lerna run prepare",
         "build:extensions": "yarn --cwd vscode && yarn compile:extensions",
         "compile:extensions": "NODE_OPTIONS=--max-old-space-size=8192 node ./src/compile.js",
         "bundle:extensions": "NODE_OPTIONS=--max-old-space-size=8192 node ./src/bundle.js",
-        "publish:latest": "node ./src/publish.js --tag=latest",
+        "publish": "yarn && yarn publish:latest",
+        "publish:latest": "node ./src/publish-vsix.js --tag=latest",
         "publish:next": "node ./src/publish.js --tag=next",
         "rebuild:browser": "theia rebuild:browser",
         "rebuild:electron": "theia rebuild:electron",
@@ -22,7 +23,8 @@
         "lerna": "2.4.0",
         "vsce": "1.70.0",
         "fs-extra": "8.1.0",
-        "capitalize": "^2.0.2"
+        "capitalize": "^2.0.2",
+        "ovsx": "latest"
     },
     "workspaces": [
         "vscode-builtin-extensions",

--- a/src/publish-vsix.js
+++ b/src/publish-vsix.js
@@ -1,0 +1,42 @@
+/**
+ * Publish individual built-in VS Code extensions to an
+ * Open VSX registry (default: open-vsx.org) . It is 
+ * assumed that the extensions to be published are present
+ * in directory "dist" at the root of this repo.
+ * 
+ * The publishing of the extensions is delegated to `ovsx`,
+ * which uses the following environment variables to know
+ * to which registry to publish-to and what personal 
+ * authentication token to use to authenticate:
+ *  OVSX_REGISTRY_URL, OVSX_PAT
+ */
+// @ts-check
+const fs = require('fs')
+const os = require('os');
+const yargs = require('yargs');
+const { root, dist, run } = require('./paths.js');
+
+const { tag } = yargs.option('tag', {
+    choices: ['latest', 'next']
+}).demandOption('tag').argv;
+
+(async () => {
+    if (tag === 'next') {
+        console.error("Open VSX does not support publishing 'next' versions at this time");
+        return;
+    }
+
+    const bin = await run('yarn', ['bin'], root());
+    const ovsx = bin.trim() + '/ovsx';
+    const result = [];
+
+    for (const vsix of fs.readdirSync(dist())) {
+        try {
+            console.log('publishing: ', dist(vsix), ' ...');
+            await run(ovsx, ['publish', dist(vsix)]);
+        } catch (e) {
+            result.push(`failed to publish ${vsix}`);
+        }
+    }
+    console.log(result.join(os.EOL));
+})();

--- a/yarn.lock
+++ b/yarn.lock
@@ -7150,7 +7150,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -8206,6 +8206,13 @@ osenv@0, osenv@^0.1.3, osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+ovsx@latest:
+  version "0.1.0-next.9321255"
+  resolved "https://registry.yarnpkg.com/ovsx/-/ovsx-0.1.0-next.9321255.tgz#dbb679e2eacf28017cfd474487a94008426d024d"
+  integrity sha512-gGQRzQWHBT6VdjZZgGxQUN1oaRxBuKcTkhtkL9AMstLqIu+tVmbTjJIE/j/RQeSumsn+HPoXysjnR0fzKsHkdQ==
+  dependencies:
+    vsce "^1.73.0"
 
 p-cancelable@^0.3.0:
   version "0.3.0"
@@ -11146,6 +11153,32 @@ vsce@1.70.0:
     didyoumean "^1.2.1"
     glob "^7.0.6"
     lodash "^4.17.10"
+    markdown-it "^8.3.1"
+    mime "^1.3.4"
+    minimatch "^3.0.3"
+    osenv "^0.1.3"
+    parse-semver "^1.1.1"
+    read "^1.0.7"
+    semver "^5.1.0"
+    tmp "0.0.29"
+    typed-rest-client "1.2.0"
+    url-join "^1.1.0"
+    yauzl "^2.3.1"
+    yazl "^2.2.2"
+
+vsce@^1.73.0:
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/vsce/-/vsce-1.74.0.tgz#ed70a20d08c70e63d21b99fc35428c4c8efc0a82"
+  integrity sha512-8zWM9bZBNn9my40kkxAxdY4nhb9ADfazXsyDgx1thbRaLPbmPTlmqQ55vCAyWYFEi6XbJv8w599vzVUqsU1gHg==
+  dependencies:
+    azure-devops-node-api "^7.2.0"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.1"
+    commander "^2.8.1"
+    denodeify "^1.2.1"
+    didyoumean "^1.2.1"
+    glob "^7.0.6"
+    lodash "^4.17.15"
     markdown-it "^8.3.1"
     mime "^1.3.4"
     minimatch "^3.0.3"


### PR DESCRIPTION
Added /src/publish-vsix.js to permit publishing to an Open VSX registry.
First run yarn to build the builtin extensions as .vsix in folder 'dist'
and remove any not wished published (e.g. not working well).

Then run:
   $> yarn publish:latest

To publish to a specific registry, use environment variable
OVSX_REGISTRY_URL to point to it. Defaults to open-vsx.org

Use environment variable OVSX_PAT to store your access token for the
registry.

Also improved the auto-generated README used in our .vsix, so it's clearer
that Microsoft is not involved in any way other than being the author of
these extensions we package and publish.

Added a copy of the VS Code license file for each builtin.

For vsix packaging, now use version number that reflects the VS Code
version as per its package.json.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>