### PR TITLE
[ci] add GH action to publish specific, solid version

### DIFF
--- a/.github/workflows/publish-vsx-specific-latest.yml
+++ b/.github/workflows/publish-vsx-specific-latest.yml
@@ -1,0 +1,38 @@
+name: ovsx-solid---publish-vscode-built-in-extensions-specific-version
+on:
+  push:
+    branches:
+      - ovsx-publish
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+      OVSX_PAT: ${{ secrets.OVSX_PAT}}
+    steps:
+      - uses: actions/checkout@v1
+      - run: |
+          git submodule init
+          git submodule update
+        name: Checkout VS Code
+      # should be aligned with https://github.com/microsoft/vscode/blob/8031c495a65de120560d27703c415eb44c3a99a1/.github/workflows/ci.yml#L22-L32
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbfile-dev pkg-config libsecret-1-dev libxss1 dbus xvfb libgtk-3-0
+          sudo cp vscode/build/azure-pipelines/linux/xvfb.init /etc/init.d/xvfb
+          sudo chmod +x /etc/init.d/xvfb
+          sudo update-rc.d xvfb defaults
+          sudo service xvfb start
+        name: Setup Build Environment
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+        name: Update vscode Repo and Checkout Latest Official Release
+      - run: yarn
+        name: Bundle Extensions
+      - run: yarn package-vsix:latest
+        name: Package Solid Version of Extensions
+      - run: yarn publish:vsix
+        name: Publish Extensions to open-vsx.org

--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ After packaging the extensions as `.vsix` (see above), you may examine/test them
 
     yarn publish:vsix
 
+## Re-publishing vscode-builtin-extensions to open-vsx
+
+There is a GH action to help: `publish-vsx-specific-latest`. For this to work, the version to be published needs to be removed from open-vsx. Then one must push to branch `ovsx-publish`. We do not care about that branch - once publish is done, it can be reset the next time. Make sure the wanted solid version of the `vscode` git submodule is checked-out in the pushed change.
+
 ## License
 
 - [Eclipse Public License 2.0](LICENSE)


### PR DESCRIPTION
It can happen that we wish to re-publish an older version of the built-ins.
ATM it's not so easy. This PR adds an action that attempts to make it easier:

Push to branch `vsx-publish` to trigger a build and publish of the vscode-builtins.
Make sure the vscode git submodule is checked-out to the targetted version.

Note: to republish, the version needs to be removed from the registry first.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>

<a href="https://gitpod.io/#https://github.com/theia-ide/vscode-builtin-extensions/pull/42"><img src="https://gitpod.io/api/apps/github/pbs/github.com/theia-ide/vscode-builtin-extensions.git/9ad13054397d88a78ab3b3f4aef02f34cd249777.svg" /></a>

