### PR TITLE
Add 'create-extension-pack' to existing workflows

### DIFF
--- a/.github/workflows/publish-vsx-latest.yml
+++ b/.github/workflows/publish-vsx-latest.yml
@@ -41,5 +41,7 @@ jobs:
         name: Bundle Extensions
       - run: yarn package-vsix:latest
         name: Package Solid Version of Extensions
+      - run: create-extension-pack:latest
+        name: Create built-in extensions pack
       - run: yarn publish:vsix
         name: Publish Extensions to open-vsx.org

--- a/.github/workflows/publish-vsx-next.yml
+++ b/.github/workflows/publish-vsx-next.yml
@@ -40,5 +40,7 @@ jobs:
         name: Bundle Extensions from vscode main
       - run: yarn package-vsix:next
         name: Package Preview Version of Extensions
+      - run: create-extension-pack:next
+        name: Create built-in extensions pack
       - run: yarn publish:vsix
         name: Publish Extensions to open-vsx.org

--- a/.github/workflows/publish-vsx-specific-latest.yml
+++ b/.github/workflows/publish-vsx-specific-latest.yml
@@ -35,5 +35,7 @@ jobs:
         name: Bundle Extensions
       - run: yarn package-vsix:latest
         name: Package Solid Version of Extensions
+      - run: create-extension-pack:latest
+        name: Create built-in extensions pack
       - run: yarn publish:vsix
         name: Publish Extensions to open-vsx.org

--- a/.github/workflows/publish-vsx-specific-next.yml
+++ b/.github/workflows/publish-vsx-specific-next.yml
@@ -34,6 +34,8 @@ jobs:
       - run: yarn
         name: Bundle Extensions
       - run: yarn package-vsix:next
-        name: Package Internediate Version of Extensions
+        name: Package Intermediate Version of Extensions
+      - run: create-extension-pack:next
+        name: Create built-in extensions pack
       - run: yarn publish:vsix
         name: Publish Extensions to open-vsx.org

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
         "publish:next": "node ./src/publish.js --tag=next",
         "package-vsix:latest": "node src/package-vsix.js --tag latest",
         "package-vsix:next": "node src/package-vsix.js --tag next",
+        "create-extension-pack:latest": "node src/create-extension-pack.js --tag latest",
+        "create-extension-pack:next": "node src/create-extension-pack.js --tag next",
         "rebuild:browser": "theia rebuild:browser",
         "rebuild:electron": "theia rebuild:electron",
         "start:browser": "yarn rebuild:browser && (cd browser-app && yarn start)",


### PR DESCRIPTION
This will enable the creation of the built-in extension pack each time a workflow is triggered.

Signed-off-by: Alvaro Sanchez-Leon <alvaro.sanchez-leon@ericsson.com>